### PR TITLE
Improve prereq parser

### DIFF
--- a/prerequisites_scraper/main.py
+++ b/prerequisites_scraper/main.py
@@ -36,7 +36,6 @@ def tokenize(prerequisites: str) -> Tokens:
     token_regex = re.compile(token_regex)
 
     # Convert regex matches to list of tokens
-    print(prerequisites)
     tokens = token_regex.finditer(prerequisites)
     tokens = map(
         lambda match: next(filter(
@@ -48,7 +47,6 @@ def tokenize(prerequisites: str) -> Tokens:
     tokens = list(tokens)
     tokens.append(("END", None))
 
-    print(tokens)
     return tokens
 
 def parse_atom(tokens: Tokens, cur_tok: int):


### PR DESCRIPTION
## Precedence fix

This fixes the precedence issue of parsing

```
Undergraduate level IHSS 1200 Minimum Grade of D or Undergraduate level ECON 1200 Minimum Grade of D and Undergraduate level MATH 1010 Minimum Grade of D or Undergraduate level MATH 1500 Minimum Grade of D
```

It does this by implementing a lexer and operator precedence parser that gives `or` greater precedence than `and`, so `A or B and C or D` is parsed the same as `(A or B) and (C or D)`.

## New output JSON format

The format of the output JSON changes a bit, so the upstream Vue code needs to be updated. IMHO, the new format is easier to parse and generate.

### Old format example

```json
{
    "type": "and",
    "solo": [
        "MATH 2400"
    ],
    "nested": [
        {
            "type": "or",
            "solo": [
                "MATH 2010",
                "MATH 2011",
                "MATH 2012"
            ],
            "nested": []
        }
    ]
}
```

### New format example

```json
{
    "type": "and",
    "nested": [
        {
            "type": "course",
            "course": "MATH 2400"
        },
        {
            "type": "or",
            "nested": [
                {
                    "type": "course",
                    "course": "MATH 2010"
                },
                {
                    "type": "course",
                    "course": "MATH 2011"
                },
                {
                    "type": "course",
                    "course": "MATH 2012"
                }
            ]
        }
    ]
}
```