### PR TITLE
sis-scraper: fix for some non-deterministic optimization behavior

### DIFF
--- a/sis_scraper/main.py
+++ b/sis_scraper/main.py
@@ -391,7 +391,7 @@ with requests.Session() as s:  # We purposefully don't use aiohttp here since SI
 
         # Reverse the list as to not break earlier offsets
         conflicts_to_prune = list(unnecessary_indices)
-        conflicts_to_prune.reverse()
+        conflicts_to_prune.sort(reverse=True)
 
         # Prune the bits in `conflicts_to_prune` from all the bitstrings
         for section_crn in conflicts:
@@ -444,7 +444,7 @@ with requests.Session() as s:  # We purposefully don't use aiohttp here since SI
 
         # Reverse the list as to not break earlier offsets
         conflicts_to_prune = list(unnecessary_indices)
-        conflicts_to_prune.reverse()
+        conflicts_to_prune.sort(reverse=True)
 
         # Prune the bits in `conflicts_to_prune` from all the bitstrings
         for section_crn in conflicts:


### PR DESCRIPTION
The code was written with the assumption that python's sets provided iteration ordering. They do not - this can lead to non-deterministic behavior on the optimizer.

The fix for this is to simply use sort() with the reverse flag instead of calling reverse()